### PR TITLE
Chrome V3 manifest compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ Consider this add-on done (except for bugfixes). I may or may not add new featur
 ## License
 
 [GPLv3](LICENSE)
+
+## Authors:
+* alct (https://github.com/alct/export-tabs-urls)
+* Gustavo (https://github.com/gusthoff)
+* Sam (https://github.com/)
+* Falko Richter (https://github.com/falkorichter)

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
-    "version": "0.2.12",
+    "version": "0.2.13",
     "default_locale": "en_US",
     "icons": {
         "16": "img/icon.svg",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
     "version": "0.2.12",
@@ -9,24 +9,13 @@
         "48": "img/icon.svg",
         "128": "img/icon.svg"
     },
-    "browser_action": {
-        "browser_style": true,
+    "action": {
         "default_icon": "img/icon.svg",
         "default_title": "__MSG_appButtonDesc__",
-        "default_popup": "popup/popup.html",
-        "theme_icons": [{
-            "light": "img/icon_dark-theme.svg",
-            "dark": "img/icon.svg",
-            "size": 16
-        }, {
-            "light": "img/icon_dark-theme.svg",
-            "dark": "img/icon.svg",
-            "size": 32
-        }]
+        "default_popup": "popup/popup.html"
     },
     "options_ui": {
-        "page": "options/options.html",
-        "browser_style": true
+        "page": "options/options.html"
     },
     "permissions": [
         "clipboardWrite",

--- a/shared/shared.js
+++ b/shared/shared.js
@@ -1,3 +1,8 @@
+// Polyfill for browser API compatibility
+if (typeof browser === 'undefined') {
+  globalThis.browser = chrome;
+}
+
 var d = document
 var w = window
 


### PR DESCRIPTION
Ran 2 agentic copilot sessions
* https://github.com/falkorichter/export-tabs-urls/pull/2/agent-sessions/3846474a-ba1d-4b06-b736-030d940c4b77
* https://github.com/falkorichter/export-tabs-urls/pull/3/agent-sessions/6766d289-b085-4a43-a95a-d562e93a5f3e
and fixed the manifest and the issue where browser was not polyfilled.

check the PRs https://github.com/falkorichter/export-tabs-urls/pull/2 and https://github.com/falkorichter/export-tabs-urls/pull/3 for details.

<img width="1624" height="1024" alt="Screenshot 2025-07-14 at 23 13 46" src="https://github.com/user-attachments/assets/add8a367-e9cb-42b1-a040-2395c01ae2b7" />
looks like it works like a charm